### PR TITLE
Add build instructions to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # dunst-project.org
 
 This is the source code for dunst website. Powered by [Hugo](http://gohugo.io/), a static site generator written in Go.
+
+# Build this site
+
+- Install hugo
+- `$ git clone --recurse-submodules https://github.com/dunst-project/dunst-project.org`
+- `$ cd dunst-project.org`
+- `$ hugo`


### PR DESCRIPTION
Add build instructions to not fool the next person about missing `header.html`. 