### PR TITLE
Make home show up as the first link in the menu

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 +++
-weight = 0
+weight = -1
 title = "Home"
 menu = "main"
 type = "page"


### PR DESCRIPTION
After an update to hugo 'home' shows up last in the top right menu,
setting the weight to -1 fixes it.