### PR TITLE
Update DBus error message explanations

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -14,9 +14,25 @@ Dunst was unable to connect to the X server. Make sure that X is running and tha
 
 If you're using the systemd service, that might mean that dbus isn't setting the right variables, see issue [#347](https://github.com/dunst-project/dunst/issues/347) for more details.
 
+## Cannot connect to DBus
+
+Dunst cannot connect to you session bus at all. The session bus might not even exist.
+
+Please check all these conditions:
+
+- dbus packages are really installed
+- dbus is running
+- The env variable `DBUS_SESSION_BUS_ADDRESS` is really set
+
+## Cannot acquire 'org.freedesktop.Notifications'
+
+Another notification daemon is already running, which is listening for notifications. Usually this is another daemon, which got autostarted or is dunst itself.
+
+Usually, dunst also prints the PID of this process, which will give you more possibilities to investigate. Maybe you want to simply `kill` this PID and then start dunst.
+
 ## Name Lost. Is Another notification daemon running?
 
-The connection to the dbus daemon failed or another process is using the notification address. Make sure that the `DBUS_SESSION_ADDRESS` environment variable is set and if not you should consult your distributions documentation on how to properly setup dbus.
+The connection to the dbus daemon failed or another process is using the notification address. Make sure that the `DBUS_SESSION_BUS_ADDRESS` environment variable is set and if not you should consult your distributions documentation on how to properly setup dbus.
 
 Additionally, verify that the output of
 


### PR DESCRIPTION
From @tsipinakis in IRC:
> I just got an email from someone who got confused with the Name Lost error - turns out the "other daemon" was dunst all along. Maybe improve that error message even more to say that dunst is already running?

Sent as Memo (from @bebehei)

> I agree, but I don't see any space for improvement in the error message. The case why you haven't got an email before is simply because it's listed in the FAQs. But the error message got changed and does not read like in the FAQs.

So, here's the improving on the website.