### PR TITLE
Release Dunst v1.3.1

### DIFF
--- a/content/changelog.md
+++ b/content/changelog.md
@@ -6,6 +6,11 @@ type = "page"
 +++
 ***
 
+## 1.3.1 - 2018-01-30
+
+### Fixed
+
+- Race condition resulting in the service files being empty (#488)
 
 ## 1.3.0 - 2018-01-05
 

--- a/content/download.md
+++ b/content/download.md
@@ -6,14 +6,20 @@ type = "page"
 +++
 ***
 
-The current stable version of Dunst is **1.3.0** released on **Jan 5 2018**.
+The current stable version of Dunst is **1.3.1** released on **Jan 30 2018**.
 
 # Downloads
 
-* [Source tarball](https://github.com/dunst-project/dunst/archive/v1.3.0.tar.gz)
+* [Source tarball](https://github.com/dunst-project/dunst/archive/v1.3.1.tar.gz)
 * [Code repository (Github)](https://github.com/dunst-project/dunst)
 
 # Release Notes
+
+Version 1.3.1 addresses a race condition that can cause the service file to be
+empty upon installation. It contains no other changes, refer to the release
+notes for 1.3 bellow for more info on 1.3.
+
+---
 
 Version 1.3 is supposed to be fully backwards compatible with 1.2.
 


### PR DESCRIPTION
In order to avoid leaving the website out of date for a long period of time I've already deployed these changes, but will update as needed if any issues arise.