### PR TITLE
FAQ: Display: Add note about wayland

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -8,11 +8,16 @@ toc = "true"
 
 # Common problems
 
-## Cannot open display
+## Errors about missing or failing to open a display
 
-Dunst was unable to connect to the X server. Make sure that X is running and that the `DISPLAY` environment variable is correctly set.
+Depending on the setup dunst was unable to connect to the X server or the wayland compositor in use. In case of X make sure that X is running and that the `DISPLAY` environment variable is correctly set. For a wayland based setup the `WAYLAND_DISPLAY` environment variable needs to be set to a valid value.
 
-If you're using the systemd service, that might mean that dbus isn't setting the right variables, see issue [#347](https://github.com/dunst-project/dunst/issues/347) for more details.
+If dunst should be automatically started by dbus or via the systemd service, it is important to know that both don't inherit environment variables set by a shell.
+There are various ways to make them aware if they're missing.  
+For a X based setup either use `systemctl --user import-environment DISPLAY` or add a call to `/etc/X11/xinit/xinitrc.d/50-systemd-user.sh` in xinitrc.  
+With a wayland setup `systemctl --user import-environment WAYLAND_DISPLAY` would be used instead.  
+If systemd knows about those environment variables, dbus should too.
+But if there are still issues with the dbus session then `dbus-update-activation-environment --systemd --all` can be used to update the current session.
 
 ## Cannot connect to DBus
 


### PR DESCRIPTION
Note the respective needed environment variable for wayland based setups in the FAQ entry.

Well, this journey was kinda embarassing :D Hadn't on my mind, that `DISPLAY` and now `WAYLAND_DISPLAY` were important for dunst. I did kinda read the issues here and there where the import of those env vars popped up, but it didn't make click.
And on my desktop dunst was working. Although I do remember that I had issues with notification timeout (which did not happen) when I tested the wayland branch back then but dunst was happily reporting the wayland usage. But well, I could live with this.
Fast forward to the beginning of July. Have a laptop which I hardly use. So never really tested dunst there. But then I needed it and thunar kinda froze on me, when unmounting devices and else. And after thunderbird popped its own notification I realized dunst wasn't running.
Which lead to the discovery of `WAYLAND_DISPLAY`. And with this set, dunst was working and did even timeout notifications. Back to the desktop I noticed a hard set `DISPLAY` \*cough\* but a missing `WAYLAND_DISPLAY`. Which in retrospect explains the erratic behaviour.
And with this I decided the add a note to the FAQ entry :)
I just added the information, but maybe it should be reworded entirely?