### PR TITLE
hugo: configure goldmark to enable inline html

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,3 +2,8 @@ languageCode = "en-us"
 title = "Dunst"
 baseurl = "https://dunst-project.org"
 theme = "liquorice"
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true


### PR DESCRIPTION
Since hugo 0.60.0 inline html is not included by default [1].
This is enabled again by this config variable.
Side note: I cannot push to master in this repo (same for dunst), but I can update the website by pushing to the gh-pages branch, since it's not protected. It would maybe be useful if I could get full push permissions, because you aren't always available to review code.

[1]: https://gohugo.io/news/0.60.0-relnotes/