### PR TITLE
Update config file for screenshot

### DIFF
--- a/content/screenshots.md
+++ b/content/screenshots.md
@@ -15,4 +15,4 @@ type = "page"
 
 <a href="/static/image.png">![alt text](/static/image.png)</a>
 
-Config file <a href="/static/dunstrc1">here</a>
+Updated config file <a href="/static/dunstrc1">here</a>

--- a/static/static/dunstrc1
+++ b/static/static/dunstrc1
@@ -1,213 +1,365 @@
+# See dunst(5) for all configuration options
+
 [global]
-font = Iosevka Term 11
+    ### Display ###
 
-# Allow a small subset of html markup:
-#   <b>bold</b>
-#   <i>italic</i>
-#   <s>strikethrough</s>
-#   <u>underline</u>
-#
-# For a complete reference see
-# <http://developer.gnome.org/pango/stable/PangoMarkupFormat.html>.
-# If markup is not allowed, those tags will be stripped out of the
-# message.
-markup = yes
-plain_text = no
+    # Which monitor should the notifications be displayed on.
+    monitor = 0
 
-# The format of the message.  Possible variables are:
-#   %a  appname
-#   %s  summary
-#   %b  body
-#   %i  iconname (including its path)
-#   %I  iconname (without its path)
-#   %p  progress value if set ([  0%] to [100%]) or nothing
-# Markup is allowed
-format = "<b>%s</b>\n%b"
+    # Display notification on focused monitor.  Possible modes are:
+    #   mouse: follow mouse pointer
+    #   keyboard: follow window with keyboard focus
+    #   none: don't follow anything
+    #
+    # "keyboard" needs a window manager that exports the
+    # _NET_ACTIVE_WINDOW property.
+    # This should be the case for almost all modern window managers.
+    #
+    # If this option is set to mouse or keyboard, the monitor option
+    # will be ignored.
+    follow = none
 
-# Sort messages by urgency.
-sort = no
+    ### Geometry ###
 
-# Show how many messages are currently hidden (because of geometry).
-indicate_hidden = yes
+    # dynamic width from 0 to 300
+    # width = (0, 300)
+    # constant width of 300
+    width = 300
 
-# Alignment of message text.
-# Possible values are "left", "center" and "right".
-alignment = center
+    # The maximum height of a single notification, excluding the frame.
+    height = 300
 
-# The frequency with wich text that is longer than the notification
-# window allows bounces back and forth.
-# This option conflicts with "word_wrap".
-# Set to 0 to disable.
-bounce_freq = 0
+    # Position the notification in the top right corner
+    origin = top-right
 
-# Show age of message if message is older than show_age_threshold
-# seconds.
-# Set to -1 to disable.
-show_age_threshold = -1
+    # Offset from the origin
+    offset = 15x49
 
-# Split notifications into multiple lines if they don't fit into
-# geometry.
-word_wrap = yes
+    # Scale factor. It is auto-detected if value is 0.
+    scale = 0
 
-# Ignore newlines '\n' in notifications.
-ignore_newline = no
+    # Maximum number of notification (0 means no limit)
+    notification_limit = 0
 
-# Hide duplicate's count and stack them
-stack_duplicates = yes
-hide_duplicate_count = yes
+    ### Progress bar ###
+
+    # Turn on the progess bar. It appears when a progress hint is passed with
+    # for example dunstify -h int:value:12
+    progress_bar = true
+
+    # Set the progress bar height. This includes the frame, so make sure
+    # it's at least twice as big as the frame width.
+    progress_bar_height = 10
+
+    # Set the frame width of the progress bar
+    progress_bar_frame_width = 1
+
+    # Set the minimum width for the progress bar
+    progress_bar_min_width = 150
+
+    # Set the maximum width for the progress bar
+    progress_bar_max_width = 300
 
 
-# The geometry of the window:
-#   [{width}]x{height}[+/-{x}+/-{y}]
-# The geometry of the message window.
-# The height is measured in number of notifications everything else
-# in pixels.  If the width is omitted but the height is given
-# ("-geometry x2"), the message window expands over the whole screen
-# (dmenu-like).  If width is 0, the window expands to the longest
-# message displayed.  A positive x is measured from the left, a
-# negative from the right side of the screen.  Y is measured from
-# the top and down respectevly.
-# The width can be negative.  In this case the actual width is the
-# screen width minus the width defined in within the geometry option.
-#geometry = "250x50-40+40"
-geometry = "300x50-15+49"
+    # Show how many messages are currently hidden (because of
+    # notification_limit).
+    indicate_hidden = yes
 
-# Shrink window if it's smaller than the width.  Will be ignored if
-# width is 0.
-shrink = no
+    # The transparency of the window.  Range: [0; 100].
+    # This option will only work if a compositing window manager is
+    # present (e.g. xcompmgr, compiz, etc.). (X11 only)
+    transparency = 5
 
-# The transparency of the window.  Range: [0; 100].
-# This option will only work if a compositing windowmanager is
-# present (e.g. xcompmgr, compiz, etc.).
-transparency = 5
+    # Draw a line of "separator_height" pixel height between two
+    # notifications.
+    # Set to 0 to disable.
+    separator_height = 2
 
-# Don't remove messages, if the user is idle (no mouse or keyboard input)
-# for longer than idle_threshold seconds.
-# Set to 0 to disable.
-idle_threshold = 0
+    # Padding between text and separator.
+    padding = 6
 
-# Which monitor should the notifications be displayed on.
-monitor = 0
+    # Horizontal padding.
+    horizontal_padding = 6
 
-# Display notification on focused monitor.  Possible modes are:
-#   mouse: follow mouse pointer
-#   keyboard: follow window with keyboard focus
-#   none: don't follow anything
-#
-# "keyboard" needs a windowmanager that exports the
-# _NET_ACTIVE_WINDOW property.
-# This should be the case for almost all modern windowmanagers.
-#
-# If this option is set to mouse or keyboard, the monitor option
-# will be ignored.
-follow = none
+    # Padding between text and icon.
+    text_icon_padding = 0
 
-# Should a notification popped up from history be sticky or timeout
-# as if it would normally do.
-sticky_history = yes
+    # Defines width in pixels of frame around the notification window.
+    # Set to 0 to disable.
+    frame_width = 3
 
-# Maximum amount of notifications kept in history
-history_length = 15
+    # Defines color of the frame around the notification window.
+    frame_color = "#8EC07C"
 
-# Display indicators for URLs (U) and actions (A).
-show_indicators = no
+    # Define a color for the separator.
+    # possible values are:
+    #  * auto: dunst tries to find a color fitting to the background;
+    #  * foreground: use the same color as the foreground;
+    #  * frame: use the same color as the frame;
+    #  * anything else will be interpreted as a X color.
+    separator_color = frame
 
-# The height of a single line.  If the height is smaller than the
-# font height, it will get raised to the font height.
-# This adds empty space above and under the text.
-line_height = 3
+    # Sort messages by urgency.
+    sort = no
 
-# Draw a line of "separatpr_height" pixel height between two
-# notifications.
-# Set to 0 to disable.
-separator_height = 2
+    # Don't remove messages, if the user is idle (no mouse or keyboard input)
+    # for longer than idle_threshold seconds.
+    # Set to 0 to disable.
+    # A client can set the 'transient' hint to bypass this. See the rules
+    # section for how to disable this if necessary
+    idle_threshold = 0
 
-# Padding between text and separator.
-padding = 6
+    ### Text ###
 
-# Horizontal padding.
-horizontal_padding = 6
+    font = Iosevka Term 11
 
-# Define a color for the separator.
-# possible values are:
-#  * auto: dunst tries to find a color fitting to the background;
-#  * foreground: use the same color as the foreground;
-#  * frame: use the same color as the frame;
-#  * anything else will be interpreted as a X color.
-separator_color = frame
+    # The spacing between lines.  If the height is smaller than the
+    # font height, it will get raised to the font height.
+    line_height = 3
 
-# Print a notification on startup.
-# This is mainly for error detection, since dbus (re-)starts dunst
-# automatically after a crash.
-startup_notification = false
+    # Possible values are:
+    # full: Allow a small subset of html markup in notifications:
+    #        <b>bold</b>
+    #        <i>italic</i>
+    #        <s>strikethrough</s>
+    #        <u>underline</u>
+    #
+    #        For a complete reference see
+    #        <https://docs.gtk.org/Pango/pango_markup.html>.
+    #
+    # strip: This setting is provided for compatibility with some broken
+    #        clients that send markup even though it's not enabled on the
+    #        server. Dunst will try to strip the markup but the parsing is
+    #        simplistic so using this option outside of matching rules for
+    #        specific applications *IS GREATLY DISCOURAGED*.
+    #
+    # no:    Disable markup parsing, incoming notifications will be treated as
+    #        plain text. Dunst will not advertise that it has the body-markup
+    #        capability if this is set as a global setting.
+    #
+    # It's important to note that markup inside the format option will be parsed
+    # regardless of what this is set to.
+    markup = full
 
-# dmenu path.
-dmenu = /usr/bin/dmenu -p dunst:
+    # The format of the message.  Possible variables are:
+    #   %a  appname
+    #   %s  summary
+    #   %b  body
+    #   %i  iconname (including its path)
+    #   %I  iconname (without its path)
+    #   %p  progress value if set ([  0%] to [100%]) or nothing
+    #   %n  progress value if set without any extra characters
+    #   %%  Literal %
+    # Markup is allowed
+    format = "<b>%s</b>\n%b"
 
-# Browser for opening urls in context menu.
-browser = /usr/bin/firefox -new-tab
+    # Alignment of message text.
+    # Possible values are "left", "center" and "right".
+    alignment = center
 
-# Align icons left/right/off
-icon_position = off
-max_icon_size = 80
+    # Vertical alignment of message text and icon.
+    # Possible values are "top", "center" and "bottom".
+    vertical_alignment = center
 
-# Paths to default icons.
-icon_path = /usr/share/icons/Paper/16x16/mimetypes/:/usr/share/icons/Paper/48x48/status/:/usr/share/icons/Paper/16x16/devices/:/usr/share/icons/Paper/48x48/notifications/:/usr/share/icons/Paper/48x48/emblems/
+    # Show age of message if message is older than show_age_threshold
+    # seconds.
+    # Set to -1 to disable.
+    show_age_threshold = -1
 
-frame_width = 3
-frame_color = "#8EC07C"
+    # Specify where to make an ellipsis in long lines.
+    # Possible values are "start", "middle" and "end".
+    ellipsize = middle
 
-[shortcuts]
+    # Ignore newlines '\n' in notifications.
+    ignore_newline = no
 
-# Shortcuts are specified as [modifier+][modifier+]...key
-# Available modifiers are "ctrl", "mod1" (the alt-key), "mod2",
-# "mod3" and "mod4" (windows-key).
-# Xev might be helpful to find names for keys.
+    # Stack together notifications with the same content
+    stack_duplicates = true
 
-# Close notification.
-close = ctrl+space
+    # Hide the count of stacked notifications with the same content
+    hide_duplicate_count = true
 
-# Close all notifications.
-close_all = ctrl+shift+space
+    # Display indicators for URLs (U) and actions (A).
+    show_indicators = no
 
-# Redisplay last message(s).
-# On the US keyboard layout "grave" is normally above TAB and left
-# of "1".
-history = ctrl+grave
+    # Split notifications into multiple lines if they don't fit into
+    # geometry.
+    word_wrap = yes
 
-# Context menu.
-context = ctrl+shift+period
+    ### Icons ###
+
+    # Align icons left/right/off
+    icon_position = off
+
+    # Scale small icons up to this size, set to 0 to disable. Helpful
+    # for e.g. small files or high-dpi screens. In case of conflict,
+    # max_icon_size takes precedence over this.
+    min_icon_size = 80
+
+    # Scale larger icons down to this size, set to 0 to disable
+    max_icon_size = 80
+
+    # Paths to default icons.
+    icon_path = /usr/share/icons/Paper/16x16/mimetypes/:/usr/share/icons/Paper/48x48/status/:/usr/share/icons/Paper/16x16/devices/:/usr/share/icons/Paper/48x48/notifications/:/usr/share/icons/Paper/48x48/emblems/:/usr/share/icons/gnome/16x16/status/:/usr/share/icons/gnome/16x16/devices/
+
+    ### History ###
+
+    # Should a notification popped up from history be sticky or timeout
+    # as if it would normally do.
+    sticky_history = yes
+
+    # Maximum amount of notifications kept in history
+    history_length = 15
+
+    ### Misc/Advanced ###
+
+    # dmenu path.
+    dmenu = /usr/bin/dmenu -p dunst:
+
+    # Browser for opening urls in context menu.
+    browser = /usr/bin/xdg-open
+
+    # Always run rule-defined scripts, even if the notification is suppressed
+    always_run_script = true
+
+    # Define the title of the windows spawned by dunst
+    title = Dunst
+
+    # Define the class of the windows spawned by dunst
+    class = Dunst
+
+    # Define the corner radius of the notification window
+    # in pixel size. If the radius is 0, you have no rounded
+    # corners.
+    # The radius will be automatically lowered if it exceeds half of the
+    # notification height to avoid clipping text and/or icons.
+    corner_radius = 0
+
+    # Ignore the dbus closeNotification message.
+    # Useful to enforce the timeout set by dunst configuration. Without this
+    # parameter, an application may close the notification sent before the
+    # user defined timeout.
+    ignore_dbusclose = false
+
+    ### Wayland ###
+    # These settings are Wayland-specific. They have no effect when using X11
+
+    # Uncomment this if you want to let notications appear under fullscreen
+    # applications (default: overlay)
+    # layer = top
+
+    # Set this to true to use X11 output on Wayland.
+    force_xwayland = false
+
+    ### Legacy
+
+    # Use the Xinerama extension instead of RandR for multi-monitor support.
+    # This setting is provided for compatibility with older nVidia drivers that
+    # do not support RandR and using it on systems that support RandR is highly
+    # discouraged.
+    #
+    # By enabling this setting dunst will not be able to detect when a monitor
+    # is connected or disconnected which might break follow mode if the screen
+    # layout changes.
+    force_xinerama = false
+
+    ### mouse
+
+    # Defines list of actions for each mouse event
+    # Possible values are:
+    # * none: Don't do anything.
+    # * do_action: Invoke the action determined by the action_name rule. If there is no
+    #              such action, open the context menu.
+    # * open_url: If the notification has exactly one url, open it. If there are multiple
+    #             ones, open the context menu.
+    # * close_current: Close current notification.
+    # * close_all: Close all notifications.
+    # * context: Open context menu for the notification.
+    # * context_all: Open context menu for all notifications.
+    # These values can be strung together for each mouse event, and
+    # will be executed in sequence.
+    mouse_left_click = close_current
+    mouse_middle_click = do_action, close_current
+    mouse_right_click = close_all
+
+# Experimental features that may or may not work correctly. Do not expect them
+# to have a consistent behaviour across releases.
+[experimental]
+    # Calculate the dpi to use on a per-monitor basis.
+    # If this setting is enabled the Xft.dpi value will be ignored and instead
+    # dunst will attempt to calculate an appropriate dpi value for each monitor
+    # using the resolution and physical size. This might be useful in setups
+    # where there are multiple screens with very different dpi values.
+    per_monitor_dpi = false
+
 
 [urgency_low]
-# IMPORTANT: colors have to be defined in quotation marks.
-# Otherwise the "#" and following would be interpreted as a comment.
-frame_color = "#3B7C87"
-foreground = "#3B7C87"
-background = "#191311"
-#background = "#2B313C"
-timeout = 4
+    # IMPORTANT: colors have to be defined in quotation marks.
+    # Otherwise the "#" and following would be interpreted as a comment.
+    frame_color = "#3B7C87"
+    foreground = "#3B7C87"
+    background = "#191311"
+    #background = "#2B313C"
+    timeout = 4
+    # Icon for notifications with low urgency, uncomment to enable
+    #default_icon = /path/to/icon
 
 [urgency_normal]
-frame_color = "#5B8234"
-foreground = "#5B8234"
-background = "#191311"
-#background = "#2B313C"
-timeout = 6
+    frame_color = "#5B8234"
+    foreground = "#5B8234"
+    background = "#191311"
+    #background = "#2B313C"
+    timeout = 6
+    # Icon for notifications with normal urgency, uncomment to enable
+    #default_icon = /path/to/icon
 
 [urgency_critical]
-frame_color = "#B7472A"
-foreground = "#B7472A"
-background = "#191311"
-#background = "#2B313C"
-timeout = 8
-
+    frame_color = "#B7472A"
+    foreground = "#B7472A"
+    background = "#191311"
+    #background = "#2B313C"
+    timeout = 8
+    # Icon for notifications with critical urgency, uncomment to enable
+    #default_icon = /path/to/icon
 
 # Every section that isn't one of the above is interpreted as a rules to
 # override settings for certain messages.
-# Messages can be matched by "appname", "summary", "body", "icon", "category",
-# "msg_urgency" and you can override the "timeout", "urgency", "foreground",
-# "background", "new_icon" and "format".
+#
+# Messages can be matched by
+#    appname (discouraged, see desktop_entry)
+#    body
+#    category
+#    desktop_entry
+#    icon
+#    match_transient
+#    msg_urgency
+#    stack_tag
+#    summary
+#
+# and you can override the
+#    background
+#    foreground
+#    format
+#    frame_color
+#    fullscreen
+#    new_icon
+#    set_stack_tag
+#    set_transient
+#    set_category
+#    timeout
+#    urgency
+#    skip_display
+#    history_ignore
+#    action_name
+#    word_wrap
+#    ellipsize
+#    alignment
+#
 # Shell-like globbing will get expanded.
+#
+# Instead of the appname filter, it's recommended to use the desktop_entry filter.
+# GLib based applications export their desktop-entry name. In comparison to the appname,
+# the desktop-entry won't get localized.
 #
 # SCRIPTING
 # You can specify a script that gets run when the rule matches by
@@ -216,10 +368,32 @@ timeout = 8
 #   script appname summary body icon urgency
 # where urgency can be "LOW", "NORMAL" or "CRITICAL".
 #
-# NOTE: if you don't want a notification to be displayed, set the format
-# to "".
 # NOTE: It might be helpful to run dunst -print in a terminal in order
 # to find fitting options for rules.
+
+# Disable the transient hint so that idle_threshold cannot be bypassed from the
+# client
+#[transient_disable]
+#    match_transient = yes
+#    set_transient = no
+#
+# Make the handling of transient notifications more strict by making them not
+# be placed in history.
+#[transient_history_ignore]
+#    match_transient = yes
+#    history_ignore = yes
+
+# fullscreen values
+# show: show the notifications, regardless if there is a fullscreen window opened
+# delay: displays the new notification, if there is no fullscreen window active
+#        If the notification is already drawn, it won't get undrawn.
+# pushback: same as delay, but when switching into fullscreen, the notification will get
+#           withdrawn from screen again and will get delayed like a new notification
+#[fullscreen_delay_everything]
+#    fullscreen = delay
+#[fullscreen_show_critical]
+#    msg_urgency = critical
+#    fullscreen = show
 
 #[espeak]
 #    summary = "*"
@@ -232,7 +406,17 @@ timeout = 8
 #[ignore]
 #    # This notification will not be displayed
 #    summary = "foobar"
-#    format = ""
+#    skip_display = true
+
+#[history-ignore]
+#    # This notification will not be saved in history
+#    summary = "foobar"
+#    history_ignore = yes
+
+#[skip-display]
+#    # This notification will not be displayed, but will be included in the history
+#    summary = "foobar"
+#    skip_display = yes
 
 #[signed_on]
 #    appname = Pidgin
@@ -253,5 +437,9 @@ timeout = 8
 #    appname = Pidgin
 #    summary = *twitter.com*
 #    urgency = normal
+#
+#[stack-volumes]
+#    appname = "some_volume_notifiers"
+#    set_stack_tag = "volume"
 #
 # vim: ft=cfg


### PR DESCRIPTION
The current config file for the screenshot is pretty old. Dunst prints several warnings when this config file is used:
```
WARNING: Setting plain_text in section global doesn't exist
WARNING: Setting bounce_freq in section global doesn't exist
WARNING: Setting geometry in section global doesn't exist
WARNING: Setting startup_notification in section global doesn't exist
WARNING: Section shortcuts is deprecated.
Acting on notifications has been moved to its own utility. For more information, see the manual for dunstctl.
Ignoring this section.
```
This PR removes obsolete options from the config file, it adds some new options and it updates the documentation.

---
I have based this off of the dunst v1.7.3 config file. I have modified some options to make it behave like the old config file. I want to change the behaviour as little as possible so that users using the old config file won't be surprized when they use the updated file. Howewer, there were still some small incompatibilities between the old and the new version of the config file.
- The `marup` and `plain_text` options have been merged into `markup`.
- The `bounce_freq` option is no longer present. This is related to  dunst-project/dunst#201.
- The height is no longer measured in number of notifications. I have used the default value of `height` (300).
- The `shrink` option is no longer present. I wasn't able to find any information about this, so I didn't put it into the updated config.
- The `startup_notification` option is no longer present. It is set to `false` in the old config, so it doesn't matter if it's missing in the new config file.
- The `browser` option is set to `/usr/bin/firefox -new-tab` in the old config. I think that using `xdg-open` (which is used in the default config file) is more appropriate, so I have replaced this with the default option.
- The `icon_path` option uses icon path for Paper icons. I put the default icon locations after Paper icons so that users without Paper icons will get at least some icons.
- The `[shortcuts]` section got removed.

This PR also notes in the screenshot page that the config file got updated.